### PR TITLE
Feat: ECS compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.0
+  - Feat: ECS compatiblity [#9](https://github.com/logstash-plugins/logstash-filter-syslog_pri/pull/9) 
+
 ## 3.0.5
   - Update gemspec summary
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,17 @@
 
 ## 3.0.1
   - Republish all the gems under jruby.
+
 ## 3.0.0
   - Update the plugin to the version 2.0 of the plugin api, this change is required for Logstash 5.0 compatibility. See https://github.com/elastic/logstash/issues/5141
-# 2.0.4
+
+## 2.0.4
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
-# 2.0.3
+
+## 2.0.3
   - New dependency requirements for logstash-core for the 5.0 release
+
 ## 2.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.1.0
-  - Feat: ECS compatiblity [#9](https://github.com/logstash-plugins/logstash-filter-syslog_pri/pull/9) 
+  - Feat: ECS compatibility [#9](https://github.com/logstash-plugins/logstash-filter-syslog_pri/pull/9) 
 
 ## 3.0.5
   - Update gemspec summary

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -35,6 +35,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-facility_labels>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-severity_labels>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-syslog_pri_field_name>> |<<string,string>>|No
@@ -45,6 +46,20 @@ Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options suppo
 filter plugins.
 
 &nbsp;
+
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+* Value type is <<string,string>>
+* Supported values are:
+** `disabled`: does not use ECS-compatible field names (for example, `syslog_severity_code` for syslog severity)
+** `v1`: uses fields that are compatible with Elastic Common Schema (for example, `[log][syslog][severity][code]`)
+* Default value depends on which version of Logstash is running:
+** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+** Otherwise, the default value is `disabled`.
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
+The value of this setting affects the _default_ value of <<plugins-{type}s-{plugin}-syslog_pri_field_name>>.
 
 [id="plugins-{type}s-{plugin}-facility_labels"]
 ===== `facility_labels` 
@@ -66,7 +81,9 @@ Labels for severity levels. This comes from RFC3164.
 ===== `syslog_pri_field_name` 
 
   * Value type is <<string,string>>
-  * Default value is `"syslog_pri"`
+  * Default value depends on whether <<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
+    ** ECS Compatibility disabled: `"syslog_pri"`
+    ** ECS Compatibility enabled: `"[log][syslog][priority]"`
 
 Name of field which passes in the extracted PRI part of the syslog message
 

--- a/logstash-filter-syslog_pri.gemspec
+++ b/logstash-filter-syslog_pri.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-syslog_pri'
-  s.version         = '3.0.5'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses the `PRI` (priority) field of a `syslog` message"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.1'
   s.add_development_dependency 'logstash-devutils'
 
 end

--- a/spec/filters/syslog_pri_spec.rb
+++ b/spec/filters/syslog_pri_spec.rb
@@ -5,9 +5,9 @@ require "logstash/event"
 
 describe LogStash::Filters::Syslog_pri do
 
-  subject          { LogStash::Filters::Syslog_pri.new( "syslog_pri_field_name" => "syslog_pri" ) }
-  let(:properties) { {:name => "foo" } }
-  let(:event)      { LogStash::Event.new(properties) }
+  subject          { LogStash::Filters::Syslog_pri.new({}) }
+  let(:event_data) { {:name => "foo" } }
+  let(:event)      { LogStash::Event.new(event_data) }
 
   it "should register without errors" do
     plugin = LogStash::Plugin.lookup("filter", "syslog_pri").new( "facility_labels" => ["kernel"] )
@@ -18,8 +18,7 @@ describe LogStash::Filters::Syslog_pri do
 
     subject          { LogStash::Filters::Syslog_pri.new( "syslog_pri_field_name" => "my_syslog_pri" ) }
 
-    let(:properties) { { "syslog_pri" => 1 } }
-    let(:event)      { LogStash::Event.new(properties) }
+    let(:event_data) { { "syslog_pri" => 1 } }
 
     before(:each) do
       subject.register
@@ -44,8 +43,7 @@ describe LogStash::Filters::Syslog_pri do
 
   describe "filtering" do
 
-    let(:properties) { { "syslog_pri" => syslog_pri } }
-    let(:event)      { LogStash::Event.new(properties) }
+    let(:event_data) { { "syslog_pri" => syslog_pri } }
 
     before(:each) do
       subject.register

--- a/spec/filters/syslog_pri_spec.rb
+++ b/spec/filters/syslog_pri_spec.rb
@@ -5,107 +5,173 @@ require "logstash/event"
 
 describe LogStash::Filters::Syslog_pri do
 
-  subject          { LogStash::Filters::Syslog_pri.new({}) }
-  let(:event_data) { {:name => "foo" } }
-  let(:event)      { LogStash::Event.new(event_data) }
+  let(:options)    { {} }
+  subject          { LogStash::Filters::Syslog_pri.new(options) }
+  let(:event_data) { { :name => "foo" } }
+  let(:event)      { LogStash::Event.new.tap { |event| event_data.each { |k, v| event.set(k, v) } } }
 
   it "should register without errors" do
     plugin = LogStash::Plugin.lookup("filter", "syslog_pri").new( "facility_labels" => ["kernel"] )
     expect { plugin.register }.to_not raise_error
   end
 
-  describe "defaults" do
+  context 'defaults', :ecs_compatibility_support do
+    ecs_compatibility_matrix(:disabled, :v1) do |ecs_select|
 
-    subject          { LogStash::Filters::Syslog_pri.new( "syslog_pri_field_name" => "my_syslog_pri" ) }
+      let(:ecs_compatibility?) { ecs_select.active_mode != :disabled }
 
-    let(:event_data) { { "syslog_pri" => 1 } }
+      let(:options)    { { "syslog_pri_field_name" => "my_syslog_pri" } }
+      let(:event_data) { { (ecs_compatibility? ? "[log][syslog][priority]" : "syslog_pri") => 1 } }
 
-    before(:each) do
-      subject.register
+      before(:each) do
+        allow_any_instance_of(described_class).to receive(:ecs_compatibility).and_return(ecs_compatibility)
+
+        subject.register
+      end
+
+      it "default syslog_facility is user-level" do
+        subject.filter(event)
+        if ecs_compatibility?
+          expect(event.get("[log][syslog][facility][name]")).to eq("user-level")
+        else
+          expect(event.get("syslog_facility")).to eq("user-level")
+        end
+      end
+
+      it "default syslog severity is notice" do
+        subject.filter(event)
+        if ecs_compatibility?
+          expect(event.get("[log][syslog][severity][name]")).to eq("notice")
+        else
+          expect(event.get("syslog_severity")).to eq("notice")
+        end
+      end
+
+      it "default severity to be 5, out of priority default 13" do
+        subject.filter(event)
+        if ecs_compatibility?
+          expect(event.get("[log][syslog][severity][code]")).to eq(5)
+        else
+          expect(event.get("syslog_severity_code")).to eq(5)
+        end
+      end
+
+      it "defaults to facility 1" do
+        subject.filter(event)
+        if ecs_compatibility?
+          expect(event.get("[log][syslog][facility][code]")).to eq(1)
+        else
+          expect(event.get("syslog_facility_code")).to eq(1)
+        end
+      end
+
     end
-
-    it "default syslog_facility is user-level" do
-      subject.filter(event)
-      expect(event.get("syslog_facility")).to eq("user-level")
-    end
-
-    it "default syslog severity is notice" do
-      subject.filter(event)
-      expect(event.get("syslog_severity")).to eq("notice")
-    end
-
-    it "default severity to be 5, out of priority default 13" do
-      subject.filter(event)
-      expect(event.get("syslog_severity_code")).to eq(5)
-    end
-
   end
 
-  describe "filtering" do
+  context 'filtering', :ecs_compatibility_support do
+    ecs_compatibility_matrix(:disabled, :v1) do |ecs_select|
 
-    let(:event_data) { { "syslog_pri" => syslog_pri } }
+      let(:ecs_compatibility?) { ecs_select.active_mode != :disabled }
 
-    before(:each) do
-      subject.register
+      let(:event_data) { { (ecs_compatibility? ? "[log][syslog][priority]" : "syslog_pri") => syslog_pri } }
+
+      before(:each) do
+        allow_any_instance_of(described_class).to receive(:ecs_compatibility).and_return(ecs_compatibility)
+
+        subject.register
+      end
+
+      context "when critical messages arrive" do
+        let(:syslog_pri) { 34 }
+
+        it "syslog severity is critical" do
+          subject.filter(event)
+          if ecs_compatibility?
+            expect(event.get("[log][syslog][severity][name]")).to eq("critical")
+          else
+            expect(event.get("syslog_severity")).to eq("critical")
+          end
+        end
+
+        it "default syslog_facility is user-level" do
+          subject.filter(event)
+          if ecs_compatibility?
+            expect(event.get("[log][syslog][facility][name]")).to eq("security/authorization")
+          else
+            expect(event.get("syslog_facility")).to eq("security/authorization")
+          end
+        end
+
+      end
+
+      context "when notice local messages arrive" do
+        let(:syslog_pri) { 165 }
+
+        it "syslog severity is notice" do
+          subject.filter(event)
+          if ecs_compatibility?
+            expect(event.get("[log][syslog][severity][name]")).to eq("notice")
+          else
+            expect(event.get("syslog_severity")).to eq("notice")
+          end
+        end
+
+        it "default syslog_facility is user-level" do
+          subject.filter(event)
+          if ecs_compatibility?
+            expect(event.get("[log][syslog][facility][name]")).to eq("local4")
+          else
+            expect(event.get("syslog_facility")).to eq("local4")
+          end
+        end
+      end
+
+      context "when a debug messages arrive" do
+        let(:syslog_pri) { 191 }
+
+        it "syslog severity is notice" do
+          subject.filter(event)
+          if ecs_compatibility?
+            expect(event.get("[log][syslog][severity][name]")).to eq("debug")
+          else
+            expect(event.get("syslog_severity")).to eq("debug")
+          end
+        end
+
+        it "default syslog_facility is user-level" do
+          subject.filter(event)
+          if ecs_compatibility?
+            expect(event.get("[log][syslog][facility][name]")).to eq("local7")
+          else
+            expect(event.get("syslog_facility")).to eq("local7")
+          end
+        end
+      end
+
+      context "when an alert messages arrive" do
+        let(:syslog_pri) { '137' }
+
+        it "syslog severity is notice" do
+          subject.filter(event)
+          if ecs_compatibility?
+            expect(event.get("[log][syslog][severity][name]")).to eq("alert")
+          else
+            expect(event.get("syslog_severity")).to eq("alert")
+          end
+        end
+
+        it "default syslog_facility is user-level" do
+          subject.filter(event)
+          if ecs_compatibility?
+            expect(event.get("[log][syslog][facility][name]")).to eq("local1")
+            expect(event.get("[log][syslog][facility][code]")).to eq(17)
+          else
+            expect(event.get("syslog_facility")).to eq("local1")
+            expect(event.get("syslog_facility_code")).to eq(17)
+          end
+        end
+      end
+
     end
-
-    context "when critical messages arrive" do
-      let(:syslog_pri) { 34 }
-
-      it "syslog severity is critical" do
-        subject.filter(event)
-        expect(event.get("syslog_severity")).to eq("critical")
-      end
-
-      it "default syslog_facility is user-level" do
-        subject.filter(event)
-        expect(event.get("syslog_facility")).to eq("security/authorization")
-      end
-
-    end
-
-    context "when notice local messages arrive" do
-      let(:syslog_pri) { 165 }
-
-      it "syslog severity is notice" do
-        subject.filter(event)
-        expect(event.get("syslog_severity")).to eq("notice")
-      end
-
-      it "default syslog_facility is user-level" do
-        subject.filter(event)
-        expect(event.get("syslog_facility")).to eq("local4")
-      end
-    end
-
-    context "when a debug messages arrive" do
-      let(:syslog_pri) { 191 }
-
-      it "syslog severity is notice" do
-        subject.filter(event)
-        expect(event.get("syslog_severity")).to eq("debug")
-      end
-
-      it "default syslog_facility is user-level" do
-        subject.filter(event)
-        expect(event.get("syslog_facility")).to eq("local7")
-      end
-    end
-
-    context "when an alert messages arrive" do
-      let(:syslog_pri) { 137 }
-
-      it "syslog severity is notice" do
-        subject.filter(event)
-        expect(event.get("syslog_severity")).to eq("alert")
-      end
-
-      it "default syslog_facility is user-level" do
-        subject.filter(event)
-        expect(event.get("syslog_facility")).to eq("local1")
-      end
-    end
-
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
 # encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
+require 'logstash/plugin_mixins/ecs_compatibility_support/spec_helper'
 require 'logstash/filters/syslog_pri'


### PR DESCRIPTION
**Elastic Common Schema Support**

using `log.syslog.` field names as prescribed by the schema

---

closing https://github.com/logstash-plugins/logstash-filter-syslog_pri/issues/8
resolves https://github.com/logstash-plugins/logstash-filter-syslog_pri/issues/6
