### PR TITLE
Tag with _syslogpriparsefailure the events that refer to facility events not present in the dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.0
+  - Feat: add tagging on unrecognized `facility_label` code [#n](https://github.com/logstash-plugins/logstash-filter-syslog_pri/pull/n)
+
 ## 3.1.1
   - Added preview of ECS-v8 support with existing ECS-v1 implementation [#10](https://github.com/logstash-plugins/logstash-filter-syslog_pri/pull/10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.2.0
+## Unreleased
   - Feat: add tagging on unrecognized `facility_label` code [#11](https://github.com/logstash-plugins/logstash-filter-syslog_pri/pull/11)
 
 ## 3.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.2.0
-  - Feat: add tagging on unrecognized `facility_label` code [#n](https://github.com/logstash-plugins/logstash-filter-syslog_pri/pull/n)
+  - Feat: add tagging on unrecognized `facility_label` code [#11](https://github.com/logstash-plugins/logstash-filter-syslog_pri/pull/11)
 
 ## 3.1.1
   - Added preview of ECS-v8 support with existing ECS-v1 implementation [#10](https://github.com/logstash-plugins/logstash-filter-syslog_pri/pull/10)

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -68,6 +68,8 @@ The value of this setting affects the _default_ value of <<plugins-{type}s-{plug
   * Default value is `["kernel", "user-level", "mail", "daemon", "security/authorization", "syslogd", "line printer", "network news", "uucp", "clock", "security/authorization", "ftp", "ntp", "log audit", "log alert", "clock", "local0", "local1", "local2", "local3", "local4", "local5", "local6", "local7"]`
 
 Labels for facility levels. This comes from RFC3164.
+If an unrecognized facility code is provided and <<plugins-{type}s-{plugin}-use_labels>> is `true` then the event
+is tagged with `_syslogpriparsefailure`.
 
 [id="plugins-{type}s-{plugin}-severity_labels"]
 ===== `severity_labels` 

--- a/lib/logstash/filters/syslog_pri.rb
+++ b/lib/logstash/filters/syslog_pri.rb
@@ -108,7 +108,7 @@ class LogStash::Filters::Syslog_pri < LogStash::Filters::Base
     # Add human-readable names after parsing severity and facility from PRI
     return unless @use_labels
 
-    # from Syslog PRI RFC 4.1.1 PRI Part, facility_code could be at most 124
+    # from Syslog PRI RFC 4.1.1 PRI Part, facility_code the maximum possible value is 124, however it defines just 23 values
     if facility_code > (@facility_labels.size - 1)
       # if the facility_code overflow the labels array
       event.tag(SYSLOGPRIPARSEFAILURE_TAG)

--- a/logstash-filter-syslog_pri.gemspec
+++ b/logstash-filter-syslog_pri.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-syslog_pri'
-  s.version         = '3.1.1'
+  s.version         = '3.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses the `PRI` (priority) field of a `syslog` message"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/syslog_pri_spec.rb
+++ b/spec/filters/syslog_pri_spec.rb
@@ -172,6 +172,15 @@ describe LogStash::Filters::Syslog_pri do
         end
       end
 
+      context "when malformed messages arrive" do
+        let(:syslog_pri) { 250 }
+
+        it "the event is tagged" do
+          subject.filter(event)
+          expect(event.get("tags")).to include("_syslogpriparsefailure")
+        end
+      end
+
     end
   end
 end

--- a/spec/filters/syslog_pri_spec.rb
+++ b/spec/filters/syslog_pri_spec.rb
@@ -172,7 +172,7 @@ describe LogStash::Filters::Syslog_pri do
         end
       end
 
-     context "when malformed messages arrive" do
+      context "when malformed messages arrive" do
         context "if syslog priority value is too high" do
           let(:syslog_pri) { 193 }
           let(:syslog_facility_code_field) { ecs_compatibility? ? "[log][syslog][facility][code]" : "syslog_facility_code" }
@@ -208,6 +208,7 @@ describe LogStash::Filters::Syslog_pri do
             expect(event.get(syslog_severity_code_field)).to eq(1)
           end
         end
+      end
     end
   end
 end

--- a/spec/filters/syslog_pri_spec.rb
+++ b/spec/filters/syslog_pri_spec.rb
@@ -172,15 +172,42 @@ describe LogStash::Filters::Syslog_pri do
         end
       end
 
-      context "when malformed messages arrive" do
-        let(:syslog_pri) { 250 }
+     context "when malformed messages arrive" do
+        context "if syslog priority value is too high" do
+          let(:syslog_pri) { 193 }
+          let(:syslog_facility_code_field) { ecs_compatibility? ? "[log][syslog][facility][code]" : "syslog_facility_code" }
+          let(:syslog_severity_code_field) { ecs_compatibility? ? "[log][syslog][severity][code]" : "syslog_severity_code" }
+          let(:syslog_facility_label_field) { ecs_compatibility? ? "[log][syslog][facility][label]" : "syslog_facility" }
+          let(:syslog_severity_label_field) { ecs_compatibility? ? "[log][syslog][severity][label]" : "syslog_severity" }
 
-        it "the event is tagged" do
-          subject.filter(event)
-          expect(event.get("tags")).to include("_syslogpriparsefailure")
+          before(:each) { subject.filter(event) }
+
+          context "if use_labels is enabled (default)" do
+            it "the event is tagged" do
+              expect(event.get("tags")).to include("_syslogpriparsefailure")
+            end
+            it "the facility label isn't set" do
+              expect(event.get(syslog_facility_label_field)).to be_nil
+            end
+            it "the severity label isn't set" do
+              expect(event.get(syslog_severity_label_field)).to be_nil
+            end
+          end
+
+          context "if use_labels is disabled" do
+            let(:options) { super().merge("use_labels" => false) }
+            it "the event is not tagged" do
+              expect(event.get("tags")).to be_nil
+            end
+          end
+
+          it "the facility code is still set" do
+            expect(event.get(syslog_facility_code_field)).to eq(24)
+          end
+          it "the severity code is still set" do
+            expect(event.get(syslog_severity_code_field)).to eq(1)
+          end
         end
-      end
-
     end
   end
 end


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
Tag with `_syslogpriparsefailure` on unrecognized `facility_label` code. 

## What does this PR do?

Check the decoded facility code before searching the corresponding label into the lookup table.


## Why is it important/What is the impact to the user?

[RFC 3164](https://www.ietf.org/rfc/rfc3164.txt) in paragraph `4.1.1 PRI Part` provides a full list of the facility codes expected.
When a syslog payload contains an invalid code, instead of crashing the pipeline, it tags the event with `_syslogpriparsefailure`

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Fixes #12
- Superseeds #13 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

```
org.jruby.RubyArray.[](org/jruby/RubyArray.java:1545)
usr.share.logstash.vendor.bundle.jruby.$2_dot_6_dot_0.gems.logstash_minus_filter_minus_syslog_pri_minus_3_dot_1_dot_1.lib.logstash.filters.syslog_pri.parse_pri(logstash-filter-syslog_pri-3.1.1/lib/logstash/filters/syslog_pri.rb:108)
usr.share.logstash.vendor.bundle.jruby.$2_dot_6_dot_0.gems.logstash_minus_filter_minus_syslog_pri_minus_3_dot_1_dot_1.lib.logstash.filters.syslog_pri.filter(logstash-filter-syslog_pri-3.1.1/lib/logstash/filters/syslog_pri.rb:81)
usr.share.logstash.logstash_minus_core.lib.logstash.filters.base.do_filter(/usr/share/logstash/logstash-core/lib/logstash/filters/base.rb:159)
usr.share.logstash.logstash_minus_core.lib.logstash.filters.base.multi_filter(/usr/share/logstash/logstash-core/lib/logstash/filters/base.rb:178)
org.jruby.RubyArray.each(org/jruby/RubyArray.java:1865)
usr.share.logstash.logstash_minus_core.lib.logstash.filters.base.multi_filter(/usr/share/logstash/logstash-core/lib/logstash/filters/base.rb:175)
org.logstash.config.ir.compiler.AbstractFilterDelegatorExt.multi_filter(org/logstash/config/ir/compiler/AbstractFilterDelegatorExt.java:134)
usr.share.logstash.logstash_minus_core.lib.logstash.java_pipeline.start_workers(/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:300)"
```