### PR TITLE
Remove spurious leftover text from "use_labels" docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.1
+  - Remove spurious leftover text from "use_labels" docs [#15](https://github.com/logstash-plugins/logstash-filter-syslog_pri/pull/15)
+
 ## 3.2.0
   - Feat: add tagging on unrecognized `facility_label` code [#11](https://github.com/logstash-plugins/logstash-filter-syslog_pri/pull/11)
   - Change: refactored test code to be streamlined when checking ECS fields [#14](https://github.com/logstash-plugins/logstash-filter-syslog_pri/pull/14)

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -95,7 +95,6 @@ Name of field which passes in the extracted PRI part of the syslog message
   * Value type is <<boolean,boolean>>
   * Default value is `true`
 
-set the status to experimental/beta/stable
 Add human-readable names after parsing severity and facility from PRI
 
 

--- a/lib/logstash/filters/syslog_pri.rb
+++ b/lib/logstash/filters/syslog_pri.rb
@@ -11,8 +11,6 @@ class LogStash::Filters::Syslog_pri < LogStash::Filters::Base
 
   config_name "syslog_pri"
 
-  # set the status to experimental/beta/stable
-
   # Add human-readable names after parsing severity and facility from PRI
   config :use_labels, :validate => :boolean, :default => true
 

--- a/logstash-filter-syslog_pri.gemspec
+++ b/logstash-filter-syslog_pri.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-syslog_pri'
-  s.version         = '3.2.0'
+  s.version         = '3.2.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses the `PRI` (priority) field of a `syslog` message"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Commit 901531b removed "milestone 1" from the Syslog_pri class but the preceding comment was left behind. The comment was effectively merged with the comment for the use_labels configuration option that followed immediately after, and this was carried over to index.asciidoc when the documentation was moved in commit 79586b7. This resulted in use_labels getting the confusing description "set the status to experimental/beta/stable Add human-readable names after parsing severity and facility from PRI".